### PR TITLE
[WIP] Add interfaces as per UML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Emacs/vim session files
+*~
+.*.sw?
+
+# OSX stuff..
+.DS_Store
+
+# Eclipse generated files
+.checkstyle
+.classpath
+.project
+.settings/
+
+# IntelliJ-IDEA generated files
+*.iml
+.idea/
+
+# Maven target
+target/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+Please note that while this repository is public, at the moment no
+contributions from outside contributors are accepted. This project
+is a TU Delft course project (TI3806) and the course rules disallow
+this. As such, for now this documents merely acts as an internal set
+of guidelines.
+
+## Submitting contributions
+
+- Make it clear in the issue tracker what you are working on.
+- Keep the [sprint backlog][trello] up to date.
+- Be descriptive in your pull request description: what is it for, why
+  is it done this way, etc, or which user story.
+- Do ***not*** make cosmetic changes to unrelated files or sections in the same pull
+  request. This creates noise, making reviews harder to do.
+
+### Tagging in the issue tracker
+
+When submitting pull requests (commonly referred to as "PRs"), include
+one of the following tags prepended to the title:
+
+- `[WIP]` - Work In Progress: the PR will change, so while there is no
+  immediate need for review, the submitter still might appreciate it.
+- `[RFC]` - Request For Comment: the PR needs reviewing and/or comments.
+- `[RDY]` - Ready: the PR has been reviewed by at least one other person and
+  has no outstanding issues.
+
+Please keep your tags up to date.
+
+### Branching & history
+
+- Do ***not*** work on your PR on the master branch, [use a feature branch
+  instead][git-feature-branch].
+- [Rebase your feature branch onto][git-rebasing] (upstream) master before
+  opening the PR.
+- Keep up to date with changes in (upstream) master so your PR is easy to
+  merge.
+- [Try to actively tidy your history][git-history-rewriting]: combine related
+  commits with interactive rebasing, separate monolithic commits, etc. If your
+  PR is still `[WIP]`, feel free to force-push to your feature branch to tidy
+  your history. Please read [how to use rebase][git-rebasing], to see how to
+  squash or otherwise edit your commits.
+
+### For code pull requests
+
+Before making a pull request, please rebase on upstream master (see above) and
+provide a clean history (see above). Please also make sure to run `mvn test`,
+to see if there are any outstanding issues (Checkstyle (see below), PMD, FindBugs, etc).
+
+#### Testing
+
+All PRs are expected to have (unit) tests to go with them. If no tests
+are provided, PRs will not be merged unless there is a viable reason.
+PRs will also not be merged if the Travis continuous integration build fails.
+
+#### Coding style
+
+For new code, run Checkstyle to detect style errors. It's not perfect,
+so some warnings may be false positives/negatives. Maven is set up to
+fail on every style error. Should Checkstyle report too much false
+positives/negatives, please edit Checkstyle's [configuration][checkstyle-config]. To have Checkstyle
+ignore certain cases, see [this][so-checkstyle] stackoverflow question.
+
+### Commit guidelines
+
+The purpose of these guidelines is to *make reviews easier* and make
+the history logs more valuable.
+
+- Try to keep the first line under 72 characters.
+- If necessary, include further description after a blank line.
+    - Don't make the description too verbose by including obvious things, but
+      don't spare clarifications for anything that may be not so obvious.
+      Some commit messages are pages long, and that's fine if there's no
+      better place for those comments to live.
+    - **Recommended:** Prefix logically-related commits with a consistent
+      identifier in each commit message. For already used identifiers, see the
+      commit history for the respective file(s) you're editing.
+      For example: `<ClassName>: fix all the issues`
+- Use the [imperative voice][imperative]: "Fix bug" rather than "Fixed bug" or "Fixes bug."
+
+### Reviewing pull requests
+
+You may find it easier to instead use an interactive program for code reviews,
+such as [`tig`][tig].
+
+<sup>Kindly taken and modified from [neovim][neovim].</sup>
+
+[checkstyle-config]: https://github.com/DNAinator/dnainator/blob/master/checkstyle.xml
+[so-checkstyle]: http://stackoverflow.com/questions/4023185/how-to-disable-a-particular-checkstyle-rule-for-a-particular-line-of-code
+[git-bisect]: http://git-scm.com/book/tr/v2/Git-Tools-Debugging-with-Git
+[git-feature-branch]: https://www.atlassian.com/git/tutorials/comparing-workflows
+[git-history-filtering]: https://www.atlassian.com/git/tutorials/git-log/filtering-the-commit-history
+[git-history-rewriting]: http://git-scm.com/book/en/v2/Git-Tools-Rewriting-History
+[git-rebasing]: http://git-scm.com/book/en/v2/Git-Branching-Rebasing
+[github-issues]: https://github.com/spoofax-shell/<project>/issues
+[imperative]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[tig]: https://github.com/jonas/tig
+[trello]: https://trello.com/b/u2aKQ12y/bachelor-project-spoofax-repl
+[neovim]: http://neovim.io/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# spoofax-shell
+# Spoofax shell [![Build Status](https://travis-ci.org/spoofax-shell/spoofax-shell.svg?branch=master)](https://travis-ci.org/spoofax-shell/spoofax-shell)
+
+TU Delft TI3806 Bachelor end project. Please see [CONTRIBUTING.md](https://github.com/spoofax-shell/spoofax-shell/blob/master/CONTRIBUTING.md)
+before opening issues or submitting pull requests.
+
+## Contributors
+
+| Name             | Student Number | E-mail                         |
+|------------------|----------------|--------------------------------|
+| Gerlof Fokkema   | 4257286        | g.r.fokkema@student.tudelft.nl |
+| Jente Hidskes    | 4335732        | hjdskes@gmail.com              |
+| Skip Lentz       | 4334051        | s.m.lentz@student.tudelft.nl   |
+
+

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="warning"/>
+    <module name="SuppressionCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+        <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+        <property name="checkFormat" value="$1"/>
+    </module>
+    <module name="TreeWalker">
+        <property name="tabWidth" value="4"/>
+        <module name="FileContentsHolder"/>
+        <module name="JavadocMethod">
+            <property name="scope" value="package"/>
+            <property name="suppressLoadErrors" value="true"/>
+        </module>
+        <module name="JavadocType"/>
+        <module name="JavadocVariable">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="JavadocStyle"/>
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="30"/>
+        </module>
+        <module name="ParameterNumber"/>
+        <module name="EmptyForIteratorPad"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="AvoidInlineConditionals"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="HiddenField">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="DesignForExtension">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier">
+            <property name="protectedAllowed" value="true"/>
+        </module>
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="TodoComment">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="UpperEll"/>
+        <module name="FallThrough"/>
+        <module name="MethodLength">
+            <property name="max" value="30"/>
+        </module>
+    </module>
+    <module name="NewlineAtEndOfFile">
+        <property name="severity" value="ignore"/>
+        <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="Translation"/>
+    <module name="FileLength"/>
+    <module name="FileTabCharacter">
+        <property name="severity" value="ignore"/>
+        <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="severity" value="ignore"/>
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Line has trailing spaces."/>
+        <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,209 +7,170 @@
     <groupId>org.metaborg.spoofax</groupId>
     <artifactId>shell</artifactId>
     <version>0.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    <name>Spoofax Shell</name>
-    <description>A REPL generator for Spoofax</description>
-    <url>https://github.com/spoofax-shell/spoofax-shell</url>
+    <packaging>pom</packaging>
 
-    <developers>
-        <developer>
-            <name>Gerlof Fokkema</name>
-            <email>g.r.fokkema@student.tudelft.nl</email>
-            <url>https://github.com/gfokkema</url>
-        </developer>
-        <developer>
-            <name>Jente Hidskes</name>
-            <email>hjdskes@gmail.com</email>
-            <url>https://unia.github.io</url>
-        </developer>
-        <developer>
-            <name>Skip Lentz</name>
-            <email>s.m.lentz@student.tudelft.nl</email>
-            <url>https://github.com/Balletie</url>
-        </developer>
-    </developers>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.metaborg</groupId>
+                <artifactId>org.metaborg.spoofax.core</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+            </dependency>
 
-    <licenses>
-        <license>
-            <name>Apache License, version 2.0</name>
-            <url>https://raw.githubusercontent.com/spoofax-shell/spoofax-shell/master/LICENSE</url>
-            <comments>The Apache license, version 2.0.</comments>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+            <!-- Test dependencies. -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>1.10.19</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>shell.client</module>
+        <module>shell.middle</module>
+        <module>shell.core</module>
+    </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <scm>
-        <connection>scm:git:git@github.com:spoofax-shell/spoofax-shell.git</connection>
-        <developerConnection>scm:git:git@github.com:spoofax-shell/spoofax-shell.git</developerConnection>
-        <url>https://github.com/spoofax-shell/spoofax-shell</url>
-    </scm>
-
-    <distributionManagement>
-        <site>
-            <id>github</id>
-            <name>Spoofax Shell GitHub repository</name>
-            <url>scm:git:https://github.com/spoofax-shell/spoofax-shell.github.io</url>
-        </site>
-    </distributionManagement>
-
-    <repositories>
-        <repository>
-            <id>metaborg-snapshot-repo</id>
-            <url>http://artifacts.metaborg.org/content/repositories/snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.metaborg</groupId>
-            <artifactId>org.metaborg.spoofax.core</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-        </dependency>
-        <!-- Test dependencies. -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
     <build>
-        <plugins>
-            <!-- Compile Java 8 sources -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <!-- Checkstyle -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
-                <dependencies>
-                    <!-- Update Checkstyle to version 6.18 at runtime -->
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>6.18</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <configLocation>${project.basedir}/checkstyle.xml</configLocation>
-                    <failOnViolation>true</failOnViolation>
-                    <logViolationsToConsole>true</logViolationsToConsole>
-                    <violationSeverity>warning</violationSeverity>
-                    <consoleOutput>false</consoleOutput>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>verify-style</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- PMD -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.6</version>
-                <!-- Using the latest version here breaks the reporting. -->
-                <!-- dependencies>
-                    <dependency>
-                        <groupId>net.sourceforge.pmd</groupId>
-                        <artifactId>pmd-java</artifactId>
-                        <version>5.4.0</version>
-                    </dependency>
-                </dependencies-->
-                <configuration>
-                    <verbose>true</verbose>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>pmd-check</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>cpd-check</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>cpd-check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- FindBugs -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.3</version>
-                <configuration>
-                    <includeTests>true</includeTests>
-                    <!-- See: http://stackoverflow.com/questions/29594445/cobertura-maven-plugin-conflicts-with-findbugs -->
-                    <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>findbugs-check</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>shell.SpoofaxShell</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <!-- Compile Java 8 sources -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.5.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+                <!-- Checkstyle -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>2.17</version>
+                    <dependencies>
+                        <!-- Update Checkstyle to version 6.18 at runtime -->
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>6.18</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <configLocation>checkstyle.xml</configLocation>
+                        <failOnViolation>true</failOnViolation>
+                        <logViolationsToConsole>true</logViolationsToConsole>
+                        <violationSeverity>warning</violationSeverity>
+                        <consoleOutput>false</consoleOutput>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>verify-style</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!-- PMD -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>3.6</version>
+                    <!-- Using the latest version here breaks the reporting. -->
+                    <!-- dependencies>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-java</artifactId>
+                            <version>5.4.0</version>
+                        </dependency>
+                    </dependencies-->
+                    <configuration>
+                        <verbose>true</verbose>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>pmd-check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>cpd-check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>cpd-check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!-- FindBugs -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>3.0.3</version>
+                    <configuration>
+                        <includeTests>true</includeTests>
+                        <!-- See: http://stackoverflow.com/questions/29594445/cobertura-maven-plugin-conflicts-with-findbugs -->
+                        <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>findbugs-check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!-- Site dependencies for deploying to git scm. Using pluginManagement for this is
+                a hack, please refer to https://jira.codehaus.org/browse/MNG-2173 -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.5.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.wagon</groupId>
+                            <artifactId>wagon-scm</artifactId>
+                            <version>2.10</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-manager-plexus</artifactId>
+                            <version>1.9.4</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-provider-gitexe</artifactId>
+                            <version>1.9.4</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-api</artifactId>
+                            <version>1.9.4</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <reporting>
@@ -230,7 +191,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <configLocation>${project.basedir}/checkstyle.xml</configLocation>
+                    <configLocation>checkstyle.xml</configLocation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                 </configuration>
             </plugin>
@@ -267,4 +228,67 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <name>Spoofax Shell</name>
+    <description>A REPL for all languages defined in Spoofax</description>
+    <url>http://spoofax-shell.github.io/</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://raw.githubusercontent.com/metaborg/spoofax-shell/master/LICENSE</url>
+            <comments>The Apache license, version 2.0.</comments>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <organization>
+        <name>Delft University of Technology</name>
+        <url>http://www.ewi.tudelft.nl/en</url>
+    </organization>
+    <developers>
+        <developer>
+            <name>Gerlof Fokkema</name>
+            <email>g.r.fokkema@student.tudelft.nl</email>
+            <url>https://github.com/gfokkema</url>
+        </developer>
+        <developer>
+            <name>Jente Hidskes</name>
+            <email>hjdskes@gmail.com</email>
+            <url>https://unia.github.io</url>
+        </developer>
+        <developer>
+            <name>Skip Lentz</name>
+            <email>s.m.lentz@student.tudelft.nl</email>
+            <url>https://github.com/Balletie</url>
+        </developer>
+    </developers>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/spoofax-shell/spoofax-shell/issues</url>
+    </issueManagement>
+    <scm>
+        <connection>scm:git:git@github.com:spoofax-shell/spoofax-shell.git</connection>
+        <developerConnection>scm:git:git@github.com:spoofax-shell/spoofax-shell.git</developerConnection>
+        <url>https://github.com/spoofax-shell/spoofax-shell</url>
+    </scm>
+    <repositories>
+        <repository>
+            <id>metaborg-snapshot-repo</id>
+            <url>http://artifacts.metaborg.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <distributionManagement>
+        <site>
+            <id>github</id>
+            <name>Spoofax Shell GitHub repository</name>
+            <url>scm:git:https://github.com/spoofax-shell/spoofax-shell.github.io/</url>
+            <!--url>scm:git:ssh://git@github.com:spoofax-shell/spoofax-shell.github.io.git</url-->
+        </site>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.metaborg.spoofax</groupId>
+    <artifactId>shell</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Spoofax Shell</name>
+    <description>A REPL generator for Spoofax</description>
+    <url>https://github.com/spoofax-shell/spoofax-shell</url>
+
+    <developers>
+        <developer>
+            <name>Gerlof Fokkema</name>
+            <email>g.r.fokkema@student.tudelft.nl</email>
+            <url>https://github.com/gfokkema</url>
+        </developer>
+        <developer>
+            <name>Jente Hidskes</name>
+            <email>hjdskes@gmail.com</email>
+            <url>https://unia.github.io</url>
+        </developer>
+        <developer>
+            <name>Skip Lentz</name>
+            <email>s.m.lentz@student.tudelft.nl</email>
+            <url>https://github.com/Balletie</url>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>Apache License, version 2.0</name>
+            <url>https://raw.githubusercontent.com/spoofax-shell/spoofax-shell/master/LICENSE</url>
+            <comments>The Apache license, version 2.0.</comments>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <scm>
+        <connection>scm:git:git@github.com:spoofax-shell/spoofax-shell.git</connection>
+        <developerConnection>scm:git:git@github.com:spoofax-shell/spoofax-shell.git</developerConnection>
+        <url>https://github.com/spoofax-shell/spoofax-shell</url>
+    </scm>
+
+    <distributionManagement>
+        <site>
+            <id>github</id>
+            <name>Spoofax Shell GitHub repository</name>
+            <url>scm:git:https://github.com/spoofax-shell/spoofax-shell.github.io</url>
+        </site>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>metaborg-snapshot-repo</id>
+            <url>http://artifacts.metaborg.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.metaborg</groupId>
+            <artifactId>org.metaborg.spoofax.core</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <!-- Test dependencies. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compile Java 8 sources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <!-- Checkstyle -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <dependencies>
+                    <!-- Update Checkstyle to version 6.18 at runtime -->
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>6.18</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>${project.basedir}/checkstyle.xml</configLocation>
+                    <failOnViolation>true</failOnViolation>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <violationSeverity>warning</violationSeverity>
+                    <consoleOutput>false</consoleOutput>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>verify-style</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- PMD -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.6</version>
+                <!-- Using the latest version here breaks the reporting. -->
+                <!-- dependencies>
+                    <dependency>
+                        <groupId>net.sourceforge.pmd</groupId>
+                        <artifactId>pmd-java</artifactId>
+                        <version>5.4.0</version>
+                    </dependency>
+                </dependencies-->
+                <configuration>
+                    <verbose>true</verbose>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pmd-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>cpd-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>cpd-check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- FindBugs -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.3</version>
+                <configuration>
+                    <includeTests>true</includeTests>
+                    <!-- See: http://stackoverflow.com/questions/29594445/cobertura-maven-plugin-conflicts-with-findbugs -->
+                    <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>findbugs-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>shell.SpoofaxShell</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.9</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
+            <!-- Checkstyle -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <configLocation>${project.basedir}/checkstyle.xml</configLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+            </plugin>
+            <!-- JavaDoc -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
+            </plugin>
+            <!-- JXR, (optional) dependency of both PMD and Checkstyle in order to xref sources. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.5</version>
+            </plugin>
+            <!-- PMD -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.6</version>
+                <configuration>
+                    <includeTests>true</includeTests>
+                    <skipEmptyReport>false</skipEmptyReport>
+                </configuration>
+            </plugin>
+            <!-- FindBugs -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.3</version>
+                <configuration>
+                    <includeTests>true</includeTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/shell.client/pom.xml
+++ b/shell.client/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shell.client</artifactId>
+    <name>Client</name>
+    <description>Spoofax Shell client</description>
+    <packaging>jar</packaging>
+
+    <parent>
+        <artifactId>shell</artifactId>
+        <groupId>org.metaborg.spoofax</groupId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <dependencies>
+        <!-- From here on, all plugins are inherited from the parent project. -->
+
+        <!-- Test dependencies. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.metaborg.spoofax.shell.client.Repl</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- From here on, all plugins are inherited from the parent project. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <!-- Correctly resolve the checkstyle config file in the parent directory. -->
+                    <configLocation>${project.parent.relativePath}/checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shell.client/pom.xml
+++ b/shell.client/pom.xml
@@ -18,7 +18,25 @@
 
     <dependencies>
         <!-- From here on, all plugins are inherited from the parent project. -->
-
+        <dependency>
+            <groupId>org.metaborg.spoofax</groupId>
+            <artifactId>shell.middle</artifactId>
+            <version>0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.metaborg</groupId>
+            <artifactId>org.metaborg.spoofax.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jline</groupId>
+            <artifactId>jline</artifactId>
+            <version>2.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <version>1.12</version>
+        </dependency>
         <!-- Test dependencies. -->
         <dependency>
             <groupId>junit</groupId>

--- a/shell.client/src/main/java/org/metaborg/spoofax/shell/client/IDisplay.java
+++ b/shell.client/src/main/java/org/metaborg/spoofax/shell/client/IDisplay.java
@@ -1,0 +1,12 @@
+package org.metaborg.spoofax.shell.client;
+
+/**
+ * An {@link IDisplay} is for displaying the results of a command or expressions that was executed,
+ * whether it was an error or a successful result.
+ */
+public interface IDisplay {
+
+    public void displayResult(String s);
+
+    public void displayError(String s);
+}

--- a/shell.client/src/main/java/org/metaborg/spoofax/shell/client/IEditor.java
+++ b/shell.client/src/main/java/org/metaborg/spoofax/shell/client/IEditor.java
@@ -1,0 +1,37 @@
+package org.metaborg.spoofax.shell.client;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.metaborg.core.completion.ICompletionService;
+import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
+
+/**
+ * An {@link IEditor} is where expressions in some language can be typed. It takes care of the
+ * prompt, keybindings, the history and multiline editing capabilities.
+ */
+public interface IEditor {
+
+    /**
+     * Get the input from the user, optionally spanning multiple lines.
+     * 
+     * @return The input typed in by the user.
+     * @throws IOException
+     */
+    public String getInput() throws IOException;
+
+    /**
+     * Set the completion service to be used when hitting TAB.
+     * 
+     * @param completionService
+     */
+    public void setSpoofaxCompletion(ICompletionService<ISpoofaxParseUnit> completionService);
+
+    /**
+     * TODO: Consider replacing List<String> with a History type?
+     * 
+     * @return the history of evaluated expressions, from recent to old.
+     */
+    public List<String> history();
+
+}

--- a/shell.client/src/main/java/org/metaborg/spoofax/shell/client/Repl.java
+++ b/shell.client/src/main/java/org/metaborg/spoofax/shell/client/Repl.java
@@ -1,0 +1,74 @@
+package org.metaborg.spoofax.shell.client;
+
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.Ansi.Color;
+import org.metaborg.core.MetaborgException;
+import org.metaborg.spoofax.core.Spoofax;
+import org.metaborg.spoofax.shell.commands.ICommandInvoker;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+
+/**
+ * Interactive REPL (Read-Eval-Print Loop) which reads an expression or command typed in by the user
+ * via an {@link IEditor}, executes them with a {@link ICommandInvoker} and prints it to an
+ * {@link IDisplay}.
+ */
+public final class Repl {
+    private ICommandInvoker invoker;
+    private IEditor editor;
+    private IDisplay display;
+
+    private Repl(ICommandInvoker invoker, InputStream in, OutputStream out, OutputStream err)
+        throws IOException {
+        this.invoker = invoker;
+        TerminalEditor editor = new TerminalEditor(in, out);
+        editor.setPrompt(coloredFg(Color.RED, "[In ]: "));
+        editor.setContinuationPrompt("[...]: ");
+        this.editor = editor;
+    }
+
+    private String coloredFg(Color c, String s) {
+        return Ansi.ansi().fg(c).a(s).reset().toString();
+    }
+
+    private void run() throws IOException {
+        System.out.println(Ansi.ansi().a("Welcome to the ").bold().a("Spoofax").reset().a(" REPL"));
+        String input;
+        while (!(input = editor.getInput()).trim().equals("exit")) {
+            if (input.length() == 0) {
+                continue;
+            }
+            try {
+                display.displayResult(invoker.execute(input));
+            } catch (IOException | MetaborgException e) {
+                display.displayError(e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * A simple test REPL.
+     * 
+     * @param args
+     *            <languagepath> <projectpath>.
+     */
+    public static void main(String[] args) {
+        if (args.length != 2) {
+            System.err.println("Usage: <languagepath> <projectpath>\n");
+            return;
+        }
+
+        try (Spoofax spoofax = new Spoofax()) {
+            SpoofaxTest test = new SpoofaxTest(spoofax, args[0], args[1]);
+            new Repl(test, System.in, System.out, System.err).run();
+        } catch (MetaborgException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/shell.client/src/main/java/org/metaborg/spoofax/shell/client/TerminalEditor.java
+++ b/shell.client/src/main/java/org/metaborg/spoofax/shell/client/TerminalEditor.java
@@ -1,0 +1,95 @@
+package org.metaborg.spoofax.shell.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.metaborg.core.completion.ICompletionService;
+import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import jline.console.ConsoleReader;
+
+/**
+ * An {@link IEditor} to be used in a terminal.
+ */
+public class TerminalEditor implements IEditor {
+    ConsoleReader reader;
+    String prompt;
+    String continuationPrompt;
+    ArrayList<String> lines;
+
+    public TerminalEditor() throws IOException {
+        this(System.in, System.out);
+    }
+
+    public TerminalEditor(InputStream in, OutputStream out) throws IOException {
+        reader = new ConsoleReader(in, out);
+        reader.setExpandEvents(false);
+        reader.setHandleUserInterrupt(true);
+        reader.setBellEnabled(true);
+        setPrompt(">>> ");
+        setContinuationPrompt("... ");
+        lines = new ArrayList<>();
+    }
+
+    protected void saveLine(String lastLine) {
+        lines.add(lastLine);
+    }
+
+    public void setPrompt(String promptString) {
+        prompt = promptString;
+    }
+
+    public void setContinuationPrompt(String promptString) {
+        continuationPrompt = promptString;
+    }
+
+    @Override
+    public void setSpoofaxCompletion(ICompletionService<ISpoofaxParseUnit> completionService) {
+        reader.addCompleter((buffer, cursor, candidates) -> {
+            return cursor;
+        });
+    }
+
+    @Override
+    public String getInput() throws IOException {
+        String input;
+        String lastLine;
+        reader.setPrompt(prompt);
+        // While the input is not empty, keep asking.
+        while ((lastLine = reader.readLine()) != null && lastLine.trim().length() > 0) {
+            reader.flush();
+            reader.setPrompt(continuationPrompt);
+            saveLine(lastLine);
+        }
+        // Concat the strings with newlines inbetween
+        input = lines.stream().reduce((left, right) -> left + "\n" + right).orElse("");
+        // Clear the lines for next input.
+        lines.clear();
+        return input;
+    }
+
+    @Override
+    public List<String> history() {
+        // @formatter:off
+        return StreamSupport.stream(reader.getHistory().spliterator(), false)
+                            .map(entry -> entry.value().toString())
+                            .collect(Collectors.toList());
+        // @formatter:on
+    }
+
+    public static void main(String[] args) throws IOException {
+        System.out.println(ansi().a("Welcome to the ").bold().a("Spoofax").reset().a(" REPL"));
+        String input = "";
+        IEditor ed = new TerminalEditor();
+        while (!(input = ed.getInput()).trim().equals("exit")) {
+            System.out.println("User typed in \"" + input + '"');
+        }
+    }
+}

--- a/shell.client/src/main/java/org/metaborg/spoofax/shell/client/package-info.java
+++ b/shell.client/src/main/java/org/metaborg/spoofax/shell/client/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package includes all of the shell client UI code.
+ */
+package org.metaborg.spoofax.shell.client;

--- a/shell.core/pom.xml
+++ b/shell.core/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shell.core</artifactId>
+    <name>Core library</name>
+    <description>Spoofax Shell core library</description>
+    <packaging>jar</packaging>
+
+    <parent>
+        <artifactId>shell</artifactId>
+        <groupId>org.metaborg.spoofax</groupId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <dependencies>
+        <!-- From here on, all plugins are inherited from the parent project. -->
+        <dependency>
+            <groupId>org.metaborg</groupId>
+            <artifactId>org.metaborg.spoofax.core</artifactId>
+        </dependency>
+
+        <!-- Test dependencies. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- From here on, all plugins are inherited from the parent project. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <!-- Correctly resolve the checkstyle config file in the parent directory. -->
+                    <configLocation>${project.parent.relativePath}/checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shell.core/pom.xml
+++ b/shell.core/pom.xml
@@ -22,7 +22,6 @@
             <groupId>org.metaborg</groupId>
             <artifactId>org.metaborg.spoofax.core</artifactId>
         </dependency>
-
         <!-- Test dependencies. -->
         <dependency>
             <groupId>junit</groupId>

--- a/shell.core/src/main/java/org/metaborg/spoofax/shell/core/package-info.java
+++ b/shell.core/src/main/java/org/metaborg/spoofax/shell/core/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The core of the shell contains the logic of evaluating a given expression in some language.
+ */
+package org.metaborg.spoofax.shell.core;

--- a/shell.middle/pom.xml
+++ b/shell.middle/pom.xml
@@ -18,7 +18,11 @@
 
     <dependencies>
         <!-- From here on, all plugins are inherited from the parent project. -->
-
+        <dependency>
+            <groupId>org.metaborg.spoofax</groupId>
+            <artifactId>shell.core</artifactId>
+            <version>0.1-SNAPSHOT</version>
+        </dependency>
         <!-- Test dependencies. -->
         <dependency>
             <groupId>junit</groupId>

--- a/shell.middle/pom.xml
+++ b/shell.middle/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shell.middle</artifactId>
+    <name>Middle-end</name>
+    <description>Spoofax Shell middle-end</description>
+    <packaging>jar</packaging>
+
+    <parent>
+        <artifactId>shell</artifactId>
+        <groupId>org.metaborg.spoofax</groupId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <dependencies>
+        <!-- From here on, all plugins are inherited from the parent project. -->
+
+        <!-- Test dependencies. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- From here on, all plugins are inherited from the parent project. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <!-- Correctly resolve the checkstyle config file in the parent directory. -->
+                    <configLocation>${project.parent.relativePath}/checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shell.middle/src/main/java/org/metaborg/spoofax/shell/commands/ICommandInvoker.java
+++ b/shell.middle/src/main/java/org/metaborg/spoofax/shell/commands/ICommandInvoker.java
@@ -1,0 +1,77 @@
+package org.metaborg.spoofax.shell.commands;
+
+/**
+ * An interface for binding and executing {@link IReplCommand}s.
+ */
+public interface ICommandInvoker {
+
+    /**
+     * Add a {@link IReplCommand} to be executed when {@code commandName} is given, under the given
+     * description.
+     * 
+     * @param commandName
+     *            The name to which the command is bound.
+     * @param description
+     *            Description of what the command does.
+     * @param c
+     *            The {@link IReplCommand} to be bound to {@code commandName}.
+     */
+    public void addCommand(String commandName, String description, IReplCommand c);
+
+    /**
+     * Same as {@link #addCommand(String, String, IReplCommand)}, with the empty {@link String}
+     * {@code ""} as description.
+     * 
+     * @param commandName
+     * @param c
+     */
+    public default void addCommand(String commandName, IReplCommand c) {
+        addCommand(commandName, "", c);
+    }
+
+    /**
+     * @param commandName
+     *            The name of an {@link IReplCommand}.
+     * @return The description of what the {@link IReplCommand} bound to {@code commandName} does.
+     */
+    public String commandDescriptionFromName(String commandName);
+
+    /**
+     * @param commandName
+     *            The name of an {@link IReplCommand}.
+     * @return The {@link IReplCommand} bound to {@code commandName}
+     */
+    public IReplCommand commandFromName(String commandName);
+
+    /**
+     * @return The prefix of the {@link IReplCommand}s. The {@link IReplCommand}s are stored without
+     *         this prefix.
+     */
+    public String commandPrefix();
+
+    /**
+     * Ensure that the given parameter is returned without the {@link #commandPrefix()}.
+     * 
+     * @param optionallyPrefixedCommandName
+     *            And optionally prefixed command name.
+     * @return The command name without prefix if found. Otherwise just the same String as the
+     *         argument
+     */
+    public default String ensureNoPrefix(String optionallyPrefixedCommandName) {
+        if (optionallyPrefixedCommandName.startsWith(commandPrefix()))
+            return optionallyPrefixedCommandName.substring(commandPrefix().length());
+        // No prefix found, so just return the argument.
+        return optionallyPrefixedCommandName;
+    }
+
+    /**
+     * Execute the {@link IReplCommand} which is bound to the given command name, minus the prefix.
+     * 
+     * @param prefixedCommandName
+     *            The name of the {@link IReplCommand} to be executed.
+     */
+    public default void execute(String prefixedCommandName) {
+        if (prefixedCommandName.startsWith(commandPrefix()))
+            commandFromName(prefixedCommandName.substring(commandPrefix().length())).execute();
+    }
+}

--- a/shell.middle/src/main/java/org/metaborg/spoofax/shell/commands/IReplCommand.java
+++ b/shell.middle/src/main/java/org/metaborg/spoofax/shell/commands/IReplCommand.java
@@ -1,0 +1,13 @@
+package org.metaborg.spoofax.shell.commands;
+
+/**
+ * Interface for REPL commands. Used together with {@link ICommandInvoker}, instances of
+ * implementors of this interface can be bound to names and descriptions.
+ */
+public interface IReplCommand {
+
+    /**
+     * Execute this command.
+     */
+    public void execute();
+}

--- a/shell.middle/src/main/java/org/metaborg/spoofax/shell/commands/package-info.java
+++ b/shell.middle/src/main/java/org/metaborg/spoofax/shell/commands/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Contains the logic for executing expressions using the core, or executing commands which are
+ * common accross frontends.
+ */
+package org.metaborg.spoofax.shell.commands;

--- a/shell.middle/src/test/java/org/metaborg/spoofax/shell/middle/ICommandInvokerTest.java
+++ b/shell.middle/src/test/java/org/metaborg/spoofax/shell/middle/ICommandInvokerTest.java
@@ -1,0 +1,52 @@
+package org.metaborg.spoofax.shell.middle;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.metaborg.spoofax.shell.commands.ICommandInvoker;
+import org.metaborg.spoofax.shell.commands.IReplCommand;
+
+/**
+ * Tests default method implementations of {@link ICommandInvoker}.
+ */
+public class ICommandInvokerTest implements ICommandInvoker {
+
+    @Test
+    public void testEnsureNoPrefix() {
+        assertEquals("Returns argument without prefix.", "expected",
+                     ensureNoPrefix(commandPrefix() + "expected"));
+    }
+
+    @Test
+    public void testExecutesCommandWithoutPrefix() {
+        execute("PREFIX/test");
+    }
+
+    @Override
+    public void addCommand(String commandName, String description, IReplCommand c) {
+    }
+
+    @Override
+    public String commandDescriptionFromName(String commandName) {
+        return null;
+    }
+
+    /**
+     * Called from {@link #testExecutesCommandWithoutPrefix()}
+     * @param commandName if correctly, without the prefix.
+     * @return an empty command.
+     */
+    @Override
+    public IReplCommand commandFromName(String commandName) {
+        assertEquals("test", commandName);
+        // Does nothing on execution.
+        return () -> {
+        };
+    }
+
+    @Override
+    public String commandPrefix() {
+        return "PREFIX/";
+    }
+
+}


### PR DESCRIPTION
We should consider adding listeners to the architecture for when a command is done. This way, each command can invoke the listener with either an error result or success result. The problem is that we may want many different kinds of error results, and it varies as to how we want to present these results to the user. Maybe this can be solved with the visitor pattern? See this UML and the embedded note:

![uml-design](https://cloud.githubusercontent.com/assets/3884925/15098761/fbef6eb4-1544-11e6-8b4e-5f10f89d381c.png)
